### PR TITLE
Travis, Databases, page editor and page editor routing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 nuxt-project/build/
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,12 @@ language: node_js
 node_js:
   - "6"
 
-sudo: false
-
 notifications:
   email:
     on_failure: always
 
 install:
+  - cd nuxt-project
   - npm install
 
 script:

--- a/nuxt-project/.gitignore
+++ b/nuxt-project/.gitignore
@@ -10,3 +10,5 @@ npm-debug.log
 
 # Nuxt generate
 dist
+
+.idea

--- a/nuxt-project/assets/endpoints/apiCall.js
+++ b/nuxt-project/assets/endpoints/apiCall.js
@@ -8,7 +8,6 @@ Promise.config({
   warnings: false,
 });
 
-
 export default function apiCall(options) {
   ['method', 'apiUrl', 'path', 'body'].forEach((option) => {
     // All options must be specified before making a call.

--- a/nuxt-project/assets/endpoints/endpoint.js
+++ b/nuxt-project/assets/endpoints/endpoint.js
@@ -5,6 +5,5 @@ export default function endpoint(details) {
   const options = details;
   options.apiCall = apiCall.bind(options);
   options.apiUrl = options.apiUrl || utils.API_URL;
-
   return options;
 }

--- a/nuxt-project/assets/endpoints/endpoints/contactEndpoint.js
+++ b/nuxt-project/assets/endpoints/endpoints/contactEndpoint.js
@@ -16,6 +16,7 @@ const contactEndpoint = endpoint({
     const options = utils.buildOptions(this.apiUrl, `${this.path}/send`, 'post', { name, email, subject, text });
     return this.apiCall(options);
   },
+
   /**
    * Gathers the current up status of the email service.
    * returns a standard 200 if all is okay but returns a 503

--- a/nuxt-project/assets/endpoints/endpoints/contactEndpoint.js
+++ b/nuxt-project/assets/endpoints/endpoints/contactEndpoint.js
@@ -4,12 +4,25 @@ import utils from '../utils';
 const contactEndpoint = endpoint({
   apiUrl: utils.API_URL,
   path: 'contact-us',
-  send(name, email) {
-    const options = utils.buildOptions(this.apiUrl, `${this.path}/send`, 'post', { name, email });
+  /**
+   * Sends a contact us email containging the contact us
+   * form content to the contactus mail box for CodeDoesGood.
+   * @param {string} name The name from contact us form.
+   * @param {string} email The email from contact us form.
+   * @param {string} subject The subject from contact us form.
+   * @param {string} text The text from contact us form.
+   */
+  send(name, email, subject, text) {
+    const options = utils.buildOptions(this.apiUrl, `${this.path}/send`, 'post', { name, email, subject, text });
     return this.apiCall(options);
   },
-  status(name, email) {
-    const options = utils.buildOptions(this.apiUrl, `${this.path}/status`, 'get', { name, email });
+  /**
+   * Gathers the current up status of the email service.
+   * returns a standard 200 if all is okay but returns a 503
+   * if its down with a standard error format.
+   */
+  status() {
+    const options = utils.buildOptions(this.apiUrl, `${this.path}/status`, 'get');
     return this.apiCall(options);
   },
 });

--- a/nuxt-project/assets/endpoints/endpoints/editorEndpoint.js
+++ b/nuxt-project/assets/endpoints/endpoints/editorEndpoint.js
@@ -5,7 +5,6 @@ import utils from '../utils';
  * This is currently preplanning code to help within the future when the
  * page editor system is setup and ready use.
  */
-
 const volunteerEndpoint = endpoint({
   apiUrl: utils.API_URL,
   path: 'editor',

--- a/nuxt-project/assets/endpoints/endpoints/editorEndpoint.js
+++ b/nuxt-project/assets/endpoints/endpoints/editorEndpoint.js
@@ -23,7 +23,7 @@ const volunteerEndpoint = endpoint({
    * @param {string} content The content that will be updating replacing the database content
    */
   updateById(id, content) {
-    const options = utils.buildOptions(this.apiUrl, `${this.path}/update/${id}`, 'get', { content });
+    const options = utils.buildOptions(this.apiUrl, `${this.path}/update/${id}`, 'post', { content });
     return this.apiCall(options);
   },
 });

--- a/nuxt-project/assets/endpoints/endpoints/editorEndpoint.js
+++ b/nuxt-project/assets/endpoints/endpoints/editorEndpoint.js
@@ -1,0 +1,32 @@
+import endpoint from '../endpoint';
+import utils from '../utils';
+
+/**
+ * This is currently preplanning code to help within the future when the
+ * page editor system is setup and ready use.
+ */
+
+const volunteerEndpoint = endpoint({
+  apiUrl: utils.API_URL,
+  path: 'editor',
+  /**
+   * Get stored page content by content id
+   * @param {number} id The id of the content to gather
+   */
+  gatherById(id) {
+    const options = utils.buildOptions(this.apiUrl, `${this.path}/gather/${id}`, 'get');
+    return this.apiCall(options);
+  },
+  /**
+   * Update the stored content within by id,the id
+   * being the id of the content of the guides or page.
+   * @param {number} id The id of the content within the database
+   * @param {string} content The content that will be updating replacing the database content
+   */
+  updateById(id, content) {
+    const options = utils.buildOptions(this.apiUrl, `${this.path}/update/${id}`, 'get', { content });
+    return this.apiCall(options);
+  },
+});
+
+export default volunteerEndpoint;

--- a/nuxt-project/assets/endpoints/endpoints/volunteerEndpoint.js
+++ b/nuxt-project/assets/endpoints/endpoints/volunteerEndpoint.js
@@ -5,7 +5,6 @@ import utils from '../utils';
  * This is currently preplanning code to help within the future when the
  * volunteer software is setup and ready for hooking into.
  */
-
 const volunteerEndpoint = endpoint({
   // Pointing to the general idea of the volunteer webapp location.
   apiUrl: 'http://volunteer.codedoesgood.org/api/',

--- a/nuxt-project/assets/endpoints/endpoints/volunteerEndpoint.js
+++ b/nuxt-project/assets/endpoints/endpoints/volunteerEndpoint.js
@@ -1,0 +1,52 @@
+import endpoint from '../endpoint';
+import utils from '../utils';
+
+/**
+ * This is currently preplanning code to help within the future when the
+ * volunteer software is setup and ready for hooking into.
+ */
+
+const volunteerEndpoint = endpoint({
+  // Pointing to the general idea of the volunteer webapp location.
+  apiUrl: 'http://volunteer.codedoesgood.org/api/',
+  path: 'volunteer',
+  /**
+   * Gather all constributors from the volunteer software
+   * general thought of a response to be a list of contributors names, id, summaries, picture url.
+   */
+  contributors() {
+    const options = utils.buildOptions(this.apiUrl, `${this.path}/contributors`, 'get');
+    return this.apiCall(options);
+  },
+  /**
+   * Gather contributor by id for displaying more information about the contributor.
+   * general thought of a response to be a list containing the contributor
+   * name, id, summary, bio, contact-details, image url.
+   * @param {*} id The id of the contributor
+   */
+  contributorById(id) {
+    const options = utils.buildOptions(this.apiUrl, `${this.path}/contributor/${id}`, 'get');
+    return this.apiCall(options);
+  },
+  /**
+   * Gather all projects from the volunteer software.
+   * general thought of a response to be a list containing the projects
+   * names, ids, summaries, image urls
+   */
+  projects() {
+    const options = utils.buildOptions(this.apiUrl, `${this.path}/projects`, 'get');
+    return this.apiCall(options);
+  },
+  /**
+   * Gather project by id for displaying more information about the project.
+   * general thought of a response to be a list containing the project
+   * name, id, summary, bio, links, image url.
+   * @param {*} id The id of the project
+   */
+  projectById(id) {
+    const options = utils.buildOptions(this.apiUrl, `${this.path}/project/${id}`, 'get');
+    return this.apiCall(options);
+  },
+});
+
+export default volunteerEndpoint;

--- a/nuxt-project/assets/endpoints/index.js
+++ b/nuxt-project/assets/endpoints/index.js
@@ -2,6 +2,8 @@ import * as apiCall from './apiCall';
 import utils from './utils';
 
 import contactEndpoint from './endpoints/contactEndpoint';
+import editorEndpoint from './endpoints/editorEndpoint';
+import volunteerEndpoint from './endpoints/volunteerEndpoint';
 
 export default function endpointApi(token = null) {
   const setUtil = (key, value) => {
@@ -16,6 +18,8 @@ export default function endpointApi(token = null) {
 
   return {
     contact: contactEndpoint,
+    editor: editorEndpoint,
+    volunteer: volunteerEndpoint,
     apiCall,
     setUtil,
     getUtil,

--- a/nuxt-project/assets/endpoints/index.js
+++ b/nuxt-project/assets/endpoints/index.js
@@ -6,10 +6,19 @@ import editorEndpoint from './endpoints/editorEndpoint';
 import volunteerEndpoint from './endpoints/volunteerEndpoint';
 
 export default function endpointApi(token = null) {
+  /**
+   * Stores a value in the client by key.
+   * @param key The indexing key.
+   * @param value The value being stored.
+   */
   const setUtil = (key, value) => {
     utils[key] = value;
   };
 
+  /**
+   * Gets a value by key from client.
+   * @param key
+   */
   const getUtil = key => utils[key];
 
   if (token !== null) {

--- a/nuxt-project/assets/endpoints/utils.js
+++ b/nuxt-project/assets/endpoints/utils.js
@@ -1,6 +1,7 @@
 const utils = {
   API_URL: '/api',
   TOKEN: '',
+
   buildOptions: (apiUrl, path, method, body = {}) => ({
     apiUrl,
     path,

--- a/nuxt-project/backend/components/configuration/configuration.js
+++ b/nuxt-project/backend/components/configuration/configuration.js
@@ -9,10 +9,10 @@ class Configuration {
     // Setting the home directory
     this.getUserHome();
 
-    // The directory to the folder path that will used
+    // The directory to the folder path that will used.
     this.folderDir = `${this.homeDirectory}${folder}`;
 
-    // The file name of the configuration file
+    // The file name of the configuration file.
     this.name = name;
 
     // The current full configuration path

--- a/nuxt-project/backend/components/configuration/defaults.js
+++ b/nuxt-project/backend/components/configuration/defaults.js
@@ -1,6 +1,6 @@
 const defaultConfig = {
 
-  // The settings used by nodemailer for sending emails (password should never be set here)
+  // The settings used by nodemailer for sending emails (password should never be set here).
   email: {
     service: 'gmail',
     email: 'contact@codedoesgood.org',

--- a/nuxt-project/backend/components/configuration/defaults.js
+++ b/nuxt-project/backend/components/configuration/defaults.js
@@ -7,6 +7,7 @@ const defaultConfig = {
     password: null,
   },
 
+  database_path: './backend/database/database.db',
   // What port the webserver will listen too, default: 80
   web_port: 80,
 };

--- a/nuxt-project/backend/components/databaseWrapper/databaseWrapper.js
+++ b/nuxt-project/backend/components/databaseWrapper/databaseWrapper.js
@@ -1,0 +1,42 @@
+const knex = require('knex');
+
+const logger = require('../logger/logger');
+
+let instance = null;
+
+/**
+ * preplanning code for a database wrapper for sqlite3.
+ */
+export default class DatbaseWrapper {
+  /**
+   * @param databasePath The path to the sqlite3 database
+   */
+  constructor(databasePath) {
+    /**
+     * Singleton setup, allows for just a since instance of the
+     * class to be stored and used across the board after a single
+     * creation is first made.
+     */
+    if (instance) {
+      return instance;
+    }
+    this.path = databasePath;
+    this.knex = null;
+
+    this.connect();
+
+    instance = this;
+  }
+
+  /**
+   * Configure knex while also test the connection to the sqlite3 database.
+   * @returns {Promise.<T>}
+   */
+  connect() {
+    this.knex = knex({ client: 'sqlite3', connection: { filename: this.path }, useNullAsDefault: true });
+
+    return this.knex.raw('SELECT 1+1 as answer')
+      .then(() => logger.info(`Successfully connected to knex database=${this.path}`))
+      .catch(error => logger.error(`Could not connect to knex database=${this.path}, error=${JSON.stringify((error))}`));
+  }
+}

--- a/nuxt-project/backend/components/databaseWrapper/databaseWrapper.js
+++ b/nuxt-project/backend/components/databaseWrapper/databaseWrapper.js
@@ -1,6 +1,8 @@
-const knex = require('knex');
+import knex from 'knex';
+import Promise from 'bluebird';
+import _ from 'lodash';
 
-const logger = require('../logger/logger');
+import logger from '../logger/logger';
 
 let instance = null;
 
@@ -22,6 +24,7 @@ export default class DatbaseWrapper {
     }
     this.path = databasePath;
     this.knex = null;
+    this.online = true;
 
     this.connect();
 
@@ -37,6 +40,64 @@ export default class DatbaseWrapper {
 
     return this.knex.raw('SELECT 1+1 as answer')
       .then(() => logger.info(`Successfully connected to knex database=${this.path}`))
-      .catch(error => logger.error(`Could not connect to knex database=${this.path}, error=${JSON.stringify((error))}`));
+      .catch((error) => {
+        this.online = false;
+        logger.error(`Could not connect to knex database=${this.path}, error=${JSON.stringify((error))}`);
+      });
+  }
+
+  /**
+   * Gets the content from the content table by id, returns the content and the id.
+   * @param id The id of the content to be grabbed.
+   */
+  getContentById(id) {
+    return new Promise((resolve, reject) => {
+      this.knex('content').select('id', 'content').where('id', id).first()
+        .then(result => resolve({ id: result.id, text: result.content }))
+        .catch(error => reject(error));
+    });
+  }
+
+  /**
+   *  Returns or rejects if the id exits or does not exist in the contents table.
+   * @param id
+   */
+  doesIdExist(id) {
+    return new Promise((resolve, reject) => {
+      this.knex('content').select('id').where('id', id).first()
+        .then((result) => {
+          if (_.isNil(result.id)) { reject(0); } else { resolve(1); }
+        })
+        .catch(() => reject(0));
+    });
+  }
+
+  /**
+   * Updates the conten in the content table by id.
+   * @param id The id of the content row.
+   * @param text The text being inserted.
+   * @param title The title being inserted.
+   * @param alias The alias being inserted.
+   * @param modifier The user updating the content.
+   */
+  updateContentById(id, content, title, alias, modifier) {
+    return new Promise((resolve, reject) => {
+      this.knex('content').where('id', id).update({
+        content,
+        title,
+        alias,
+        modified_by: modifier,
+        modified_date: new Date(),
+      })
+        .then(() => resolve(true))
+        .catch(error => reject(error));
+    });
+  }
+
+  /**
+   * @returns {boolean} Online Status
+   */
+  getStatus() {
+    return this.online;
   }
 }

--- a/nuxt-project/backend/components/databaseWrapper/databaseWrapper.js
+++ b/nuxt-project/backend/components/databaseWrapper/databaseWrapper.js
@@ -52,8 +52,8 @@ export default class DatbaseWrapper {
    */
   getContentById(id) {
     return new Promise((resolve, reject) => {
-      this.knex('content').select('id', 'content').where('id', id).first()
-        .then(result => resolve({ id: result.id, text: result.content }))
+      this.knex('content').select('*').where('id', id).first()
+        .then(result => resolve({ ...result }))
         .catch(error => reject(error));
     });
   }
@@ -80,10 +80,10 @@ export default class DatbaseWrapper {
    * @param alias The alias being inserted.
    * @param modifier The user updating the content.
    */
-  updateContentById(id, content, title, alias, modifier) {
+  updateContentById(id, text, title, alias, modifier) {
     return new Promise((resolve, reject) => {
       this.knex('content').where('id', id).update({
-        content,
+        text,
         title,
         alias,
         modified_by: modifier,
@@ -93,6 +93,29 @@ export default class DatbaseWrapper {
         .catch(error => reject(error));
     });
   }
+
+  /**
+   * Add content to the content table of the database
+   * @param title Title of the artical.
+   * @param alias Alias of the artical.
+   * @param text Text for the artical.
+   * @param createdBy User who created the artical.
+   */
+  addContent(title, alias, text, createdBy) {
+    return new Promise((resolve, reject) => {
+      this.knex('content').insert({
+        title,
+        alias,
+        text,
+        created_by: createdBy,
+        modified_date: new Date().toLocaleString(),
+        modified_by: createdBy,
+      })
+        .then(() => resolve(true))
+        .catch(error => reject(error));
+    });
+  }
+
 
   /**
    * @returns {boolean} Online Status

--- a/nuxt-project/backend/components/email/email.js
+++ b/nuxt-project/backend/components/email/email.js
@@ -16,12 +16,11 @@ export default class Email {
     this.transporter = this.build(options.password);
 
     // Status for checking that the email connection is working.
-    this.online = false;
+    this.online = true;
 
     this.verify()
     .then(() => {
       logger.info(`Email Client is ready, service=${this.service}, email=${this.username}`);
-      this.online = true;
     })
     .catch((error) => {
       logger.error(`Error creating email connection, error=${error}`);

--- a/nuxt-project/backend/components/email/email.js
+++ b/nuxt-project/backend/components/email/email.js
@@ -19,13 +19,13 @@ export default class Email {
     this.online = true;
 
     this.verify()
-    .then(() => {
-      logger.info(`Email Client is ready, service=${this.service}, email=${this.username}`);
-    })
-    .catch((error) => {
-      logger.error(`Error creating email connection, error=${error}`);
-      this.online = false;
-    });
+      .then(() => {
+        logger.info(`Email Client is ready, service=${this.service}, email=${this.username}`);
+      })
+      .catch((error) => {
+        logger.error(`Error creating email connection, error=${error}`);
+        this.online = false;
+      });
   }
 
   /**

--- a/nuxt-project/backend/components/email/email.js
+++ b/nuxt-project/backend/components/email/email.js
@@ -6,16 +6,16 @@ import logger from '../logger/logger';
 
 export default class Email {
   constructor(options) {
-    // The type of service used for emailing
+    // The type of service used for emailing.
     this.service = options.service;
 
-    // The email that will be used to make the connection
+    // The email that will be used to make the connection.
     this.username = options.email;
 
     // Transporter that will be sending the emails
     this.transporter = this.build(options.password);
 
-    // Status for checking that the email connection is working
+    // Status for checking that the email connection is working.
     this.online = false;
 
     this.verify()
@@ -30,8 +30,8 @@ export default class Email {
   }
 
   /**
-   * Builds the transporter from nodemailer that will be used to send the emails
-   * @param {string} pass The password that is being used to authenticate with the service
+   * Builds the transporter from nodemailer that will be used to send the emails.
+   * @param {string} pass The password that is being used to authenticate with the service.
    */
   build(pass) {
     return nodemailer.createTransport({
@@ -46,7 +46,7 @@ export default class Email {
 
   /**
    * Verifies the connection the service.
-   * @param {function} callback The callback function to confirm the connection
+   * @param {function} callback The callback function to confirm the connection.
    */
   verify() {
     return new Promise((resolve, reject) => {
@@ -63,7 +63,7 @@ export default class Email {
   /**
    * Returns a build object ready to be passed into the transporter for sending a email.
    * @param {object} message The object containing the message details,
-   * from, to, subject, text, html
+   * from, to, subject, text, html.
    */
   buildMessage(message) {
     return {
@@ -76,10 +76,10 @@ export default class Email {
   }
 
   /**
-   * Sends a email to the provided person with the provided content
-   * @param {string} to The person who is getting sent the email
-   * @param {string} subject The subject text for the email
-   * @param {string} text  The content text for the email
+   * Sends a email to the provided person with the provided content.
+   * @param {string} to The person who is getting sent the email.
+   * @param {string} subject The subject text for the email.
+   * @param {string} text  The content text for the email.
    * @param {string} html The html to be used instead of the text (defaults to the text)
    */
   send(from, to, subject, text, html = undefined) {
@@ -96,7 +96,7 @@ export default class Email {
   }
 
   /**
-   * Returns the online status of the email service (true, false)
+   * Returns the online status of the email service (true, false).
    */
   getStatus() {
     return this.online;

--- a/nuxt-project/backend/components/logger/logger.js
+++ b/nuxt-project/backend/components/logger/logger.js
@@ -5,9 +5,7 @@ const logLevels = {
     error: 0,
     warn: 1,
     info: 2,
-    verbose: 3,
     debug: 4,
-    silly: 5,
   },
 };
 

--- a/nuxt-project/backend/index.js
+++ b/nuxt-project/backend/index.js
@@ -25,6 +25,9 @@ if (nuxtConfiguration.dev) {
   });
 }
 
+/**
+ * Binds all routes to /api before nuxt does, this allows us to preserve our requests routes.
+ */
 app.use('/api', routes);
 app.use(nuxt.render);
 

--- a/nuxt-project/backend/index.js
+++ b/nuxt-project/backend/index.js
@@ -14,7 +14,6 @@ nuxtConfiguration.dev = !(process.env.NODE_ENV === 'production');
 
 // Pass the configuration to setup Nuxt
 const nuxt = new Nuxt(nuxtConfiguration);
-app.use(bodyParser.urlencoded({ extended: false }));
 
 // Build the nuxt if the configuration is in dev mode
 if (nuxtConfiguration.dev) {
@@ -28,6 +27,8 @@ if (nuxtConfiguration.dev) {
 /**
  * Binds all routes to /api before nuxt does, this allows us to preserve our requests routes.
  */
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
 app.use('/api', routes);
 app.use(nuxt.render);
 

--- a/nuxt-project/backend/middleware/contact.js
+++ b/nuxt-project/backend/middleware/contact.js
@@ -73,7 +73,7 @@ function sendContactUsRequestInbox(req, res) {
  * Sends OK or Internal Server Error based on the true / false email status
  */
 function sendContactUsEmailStatus(req, res) {
-  if (email.getStatus()) { res.sendStatus(200); } else { res.status(500).send({ error: 'Unavailable Service', description: 'Email service is currently unavailable or down' }); }
+  if (email.getStatus()) { res.sendStatus(200); } else { res.status(503).send({ error: 'Unavailable Service', description: 'Email service is currently unavailable or down' }); }
 }
 
 export default {

--- a/nuxt-project/backend/middleware/contact.js
+++ b/nuxt-project/backend/middleware/contact.js
@@ -70,7 +70,7 @@ function sendContactUsRequestInbox(req, res) {
 }
 
 /**
- * Sends OK or Internal Server Error based on the true / false email status
+ * Sends OK or Internal Server Error based on the true / false email status.
  */
 function sendContactUsEmailStatus(req, res) {
   if (email.getStatus()) { res.sendStatus(200); } else { res.status(503).send({ error: 'Unavailable Service', description: 'Email service is currently unavailable or down' }); }

--- a/nuxt-project/backend/middleware/editor.js
+++ b/nuxt-project/backend/middleware/editor.js
@@ -1,0 +1,124 @@
+import _ from 'lodash';
+
+import Configuration from '../components/configuration/configuration';
+import DatabaseWrapper from '../components/databaseWrapper/databaseWrapper';
+import logger from '../components/logger/logger';
+
+const config = new Configuration('CodeDoesGood', 'CodeDoesGoodWebsite.json');
+const databaseWrapper = new DatabaseWrapper(config.getKey('database_path'));
+
+/**
+ * Validates that the email service is currently working before even attempting to continue
+ */
+function validateDatabaseConnectionStatus(req, res, next) {
+  if (databaseWrapper.getStatus()) { return next(); }
+  return res.status(503).send({ error: 'Unavailable Service', description: 'Content service is currently unavailable or down' });
+}
+
+/**
+ * Validates the users name, email and text that as been sent.
+ */
+function validateContentId(req, res, next) {
+  const contentId = parseInt((req.params.id), 10);
+
+  /**
+   * Validate that the contentId is a valid number and not containing any letters.
+   */
+  if (isNaN(contentId)) {
+    res.status(400).send({ error: 'invalid id', description: 'Id provided was not a valid number' });
+  }
+
+  /**
+   * Checks to see if the id exists in the database, continues if it exists otherwise
+   * it will reject and and sends a bad request (400) back to the client.
+   */
+  databaseWrapper.doesIdExist(contentId)
+    .then(() => {
+      req.contentId = contentId;
+      next();
+    })
+    .catch(() => res.status(400).send({ error: 'invalid id', description: 'Id does not exist' }));
+}
+
+/**
+ * This will validate the authenication token when authentication is added for updating
+ * and adjusting content with a editing section of the website.
+ */
+function validateAuthenticationToken(req, res/* , next */) {
+  // const token = req.params.token;
+  /**
+   * todo: Setup authentication with jwt tokens and validate here.
+   */
+  return res.status(503).send({ error: 'Authentication', description: 'Updating content is currently unavailable' });
+  // next();
+}
+
+/**
+ * Validates that the content being requested to be updated is a valid string and not null
+ */
+function validateContentBeingUpdated(req, res, next) {
+  const content = req.body.content;
+
+  if (_.isNil(content)) {
+    res.status(400).send({ error: 'Content Validation', description: 'Content is not in a valid format' });
+  }
+
+  const text = content.text;
+  const title = content.title;
+  const alias = content.alias;
+  const modifier = content.modifier;
+
+  if (_.isNil(text) || !_.isString(text)) {
+    res.status(400).send({ error: 'Content Validation', description: 'Content text is not in a valid format' });
+  } else if (_.isNil(alias) || !_.isString(alias)) {
+    res.status(400).send({ error: 'Content Validation', description: 'Content alias is not in a valid format' });
+  } else if (_.isNil(title) || !_.isString(title)) {
+    res.status(400).send({ error: 'Content Validation', description: 'Content title is not in a valid format' });
+  } else if (_.isNil(modifier) || !_.isString(modifier)) {
+    res.status(400).send({ error: 'Content Validation', description: 'Content modifier is not in a valid format' });
+  }
+
+  req.content = content;
+  next();
+}
+
+/**
+ * Updates the content in the content table by id.
+ */
+function updateContentByIdForRequestingUser(req, res) {
+  const content = req.content;
+  const contentId = req.contentId;
+
+  const text = content.text;
+  const title = content.title;
+  const alias = content.alias;
+  const modifier = content.modifier;
+
+  databaseWrapper.updateContentById(contentId, text, title, alias, modifier)
+    .then(() => res.status(200).send({ message: `Content updated for ${content.title}` }))
+    .catch(error => res.status(500).send({ error: 'Updating', description: `Failed to update content for ${content.title}, error=${JSON.stringify(error)}` }));
+}
+
+/**
+ * Sends the content of the content table to the requesting user by using the
+ * contentId that was validated before hand.
+ */
+function sendContentByIdForRequestingUser(req, res) {
+  const contentId = req.contentId;
+
+  databaseWrapper.getContentById(contentId)
+    .then(result => res.status(200).send({ message: `content for id ${contentId}`, content: { text: result.text } }))
+    .catch((error) => {
+      logger.warn(`Error gathering content for id ${contentId}, error=${JSON.stringify(error)}`);
+      res.status(500).send({ error: 'content error', description: `Unable to gather content for id ${contentId}` });
+    });
+}
+
+export default {
+  validateDatabaseConnectionStatus,
+  validateContentBeingUpdated,
+  updateContentByIdForRequestingUser,
+  sendContentByIdForRequestingUser,
+  validateAuthenticationToken,
+  validateContentId,
+};

--- a/nuxt-project/backend/routes/contact.js
+++ b/nuxt-project/backend/routes/contact.js
@@ -3,6 +3,14 @@ import contact from '../middleware/contact';
 
 const router = Router();
 
+/**
+ * Routing for all contact us processes.
+ *
+ * validate that the service is up and running.
+ * Validate all information is provided.
+ * Deny any blocked domains or requests.
+ * Send the email to the contact us inbox.
+ */
 router.post('/contact-us/send', [
   contact.validateEmailConnectionStatus.bind(this),
   contact.validateContactUsRequestInformation.bind(this),
@@ -10,6 +18,9 @@ router.post('/contact-us/send', [
   contact.sendContactUsRequestInbox.bind(this),
 ]);
 
+/**
+ * Routing process for getting the status of the contactus system
+ */
 router.get('/contact-us/status', [
   contact.sendContactUsEmailStatus.bind(this),
 ]);

--- a/nuxt-project/backend/routes/editor.js
+++ b/nuxt-project/backend/routes/editor.js
@@ -1,0 +1,26 @@
+import { Router } from 'express';
+import editor from '../middleware/editor';
+
+const router = Router();
+
+/**
+ * Returns the content requested by id if it exists.
+ */
+router.get('/editor/gather/:id', [
+  editor.validateDatabaseConnectionStatus.bind(this),
+  editor.validateContentId.bind(this),
+  editor.sendContentByIdForRequestingUser.bind(this),
+]);
+
+/**
+ * Todo: Verify token that was authenticated with.
+ */
+router.post('/editor/update/:id', [
+  editor.validateDatabaseConnectionStatus.bind(this),
+  editor.validateAuthenticationToken.bind(this),
+  editor.validateContentBeingUpdated.bind(this),
+  editor.validateContentId.bind(this),
+  editor.updateContentByIdForRequestingUser.bind(this),
+]);
+
+export default router;

--- a/nuxt-project/backend/routes/editor.js
+++ b/nuxt-project/backend/routes/editor.js
@@ -18,9 +18,19 @@ router.get('/editor/gather/:id', [
 router.post('/editor/update/:id', [
   editor.validateDatabaseConnectionStatus.bind(this),
   editor.validateAuthenticationToken.bind(this),
-  editor.validateContentBeingUpdated.bind(this),
+  editor.validateContent.bind(this),
   editor.validateContentId.bind(this),
   editor.updateContentByIdForRequestingUser.bind(this),
+]);
+
+/**
+ * Todo: Verify token that was authenticated with.
+ */
+router.post('/editor/insert', [
+  editor.validateDatabaseConnectionStatus.bind(this),
+  editor.validateAuthenticationToken.bind(this),
+  editor.validateContent.bind(this),
+  editor.insertContentIntoDatabase.bind(this),
 ]);
 
 export default router;

--- a/nuxt-project/backend/routes/index.js
+++ b/nuxt-project/backend/routes/index.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import contact from './contact';
+import editor from './editor';
 
 const router = Router();
 
@@ -8,5 +9,6 @@ const router = Router();
  * express routing system.
  */
 router.use(contact);
+router.use(editor);
 
 export default router;

--- a/nuxt-project/backend/routes/index.js
+++ b/nuxt-project/backend/routes/index.js
@@ -3,6 +3,10 @@ import contact from './contact';
 
 const router = Router();
 
+/**
+ * Binding all contact routes to be used within the
+ * express routing system.
+ */
 router.use(contact);
 
 export default router;

--- a/nuxt-project/backpack.config.js
+++ b/nuxt-project/backpack.config.js
@@ -1,3 +1,4 @@
+
 module.exports = {
   webpack: (config) => {
     const configuration = config;

--- a/nuxt-project/layouts/default.vue
+++ b/nuxt-project/layouts/default.vue
@@ -1,19 +1,19 @@
 <template>
   <div>
-    <Head/>
+    <HeadComponent/>
     <nuxt/>
-    <Foot/>
+    <FootComponent/>
   </div>
 </template>
 
 <script>
-import Foot from '~components/Footer.vue';
-import Head from '~components/Header.vue';
+import FootComponent from '~components/Footer.vue';
+import HeadComponent from '~components/Header.vue';
 
 export default {
   components: {
-    Foot,
-    Head,
+    FootComponent,
+    HeadComponent,
   },
 };
 </script>

--- a/nuxt-project/nuxt.config.js
+++ b/nuxt-project/nuxt.config.js
@@ -17,9 +17,7 @@ module.exports = {
   ** Customize the progress-bar color
   */
   loading: { color: '#3B8070' },
-  /*
-  ** Build configuration
-  */
+
   build: {
     /*
     ** Run ESLINT on save

--- a/nuxt-project/package-lock.json
+++ b/nuxt-project/package-lock.json
@@ -5770,6 +5770,677 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "sqlite3": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.8.tgz",
+      "integrity": "sha1-TLz5Zdi5AdGxAVy8f8QVquFX36o=",
+      "dependencies": {
+        "nan": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
+          "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI="
+        },
+        "node-pre-gyp": {
+          "version": "0.6.31",
+          "bundled": true,
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.6",
+              "bundled": true,
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.9",
+                  "bundled": true
+                }
+              }
+            },
+            "npmlog": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "dependencies": {
+                    "delegates": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "readable-stream": {
+                      "version": "2.1.5",
+                      "bundled": true,
+                      "dependencies": {
+                        "buffer-shims": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "bundled": true
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "bundled": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "bundled": true
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "gauge": {
+                  "version": "2.6.0",
+                  "bundled": true,
+                  "dependencies": {
+                    "aproba": {
+                      "version": "1.0.4",
+                      "bundled": true
+                    },
+                    "has-color": {
+                      "version": "0.1.7",
+                      "bundled": true
+                    },
+                    "has-unicode": {
+                      "version": "2.0.1",
+                      "bundled": true
+                    },
+                    "object-assign": {
+                      "version": "4.1.0",
+                      "bundled": true
+                    },
+                    "signal-exit": {
+                      "version": "3.0.1",
+                      "bundled": true
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.0.1",
+                          "bundled": true,
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "wide-align": {
+                      "version": "1.1.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "rc": {
+              "version": "1.1.6",
+              "bundled": true,
+              "dependencies": {
+                "deep-extend": {
+                  "version": "0.4.1",
+                  "bundled": true
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "bundled": true
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true
+                },
+                "strip-json-comments": {
+                  "version": "1.0.4",
+                  "bundled": true
+                }
+              }
+            },
+            "request": {
+              "version": "2.76.0",
+              "bundled": true,
+              "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "bundled": true
+                },
+                "aws4": {
+                  "version": "1.5.0",
+                  "bundled": true
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "bundled": true
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "bundled": true
+                },
+                "form-data": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "dependencies": {
+                    "asynckit": {
+                      "version": "0.4.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "har-validator": {
+                  "version": "2.0.6",
+                  "bundled": true,
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "bundled": true,
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "bundled": true
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "bundled": true
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "commander": {
+                      "version": "2.9.0",
+                      "bundled": true,
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.15.0",
+                      "bundled": true,
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "bundled": true,
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "4.0.0",
+                          "bundled": true
+                        },
+                        "xtend": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "bundled": true,
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1",
+                      "bundled": true
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "bundled": true
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "bundled": true
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "bundled": true
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "bundled": true
+                    },
+                    "jsprim": {
+                      "version": "1.3.1",
+                      "bundled": true,
+                      "dependencies": {
+                        "extsprintf": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        },
+                        "json-schema": {
+                          "version": "0.2.3",
+                          "bundled": true
+                        },
+                        "verror": {
+                          "version": "1.3.6",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.10.1",
+                      "bundled": true,
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.2.3",
+                          "bundled": true
+                        },
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "bcrypt-pbkdf": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "optional": true
+                        },
+                        "dashdash": {
+                          "version": "1.14.0",
+                          "bundled": true
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "bundled": true,
+                          "optional": true
+                        },
+                        "getpass": {
+                          "version": "0.1.6",
+                          "bundled": true
+                        },
+                        "jodid25519": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "optional": true
+                        },
+                        "jsbn": {
+                          "version": "0.1.0",
+                          "bundled": true,
+                          "optional": true
+                        },
+                        "tweetnacl": {
+                          "version": "0.14.3",
+                          "bundled": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "bundled": true
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "bundled": true
+                },
+                "mime-types": {
+                  "version": "2.1.12",
+                  "bundled": true,
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.24.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.7",
+                  "bundled": true
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "bundled": true
+                },
+                "qs": {
+                  "version": "6.3.0",
+                  "bundled": true
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "bundled": true
+                },
+                "tough-cookie": {
+                  "version": "2.3.2",
+                  "bundled": true,
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.4.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.4.3",
+                  "bundled": true
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.5.4",
+              "bundled": true,
+              "dependencies": {
+                "glob": {
+                  "version": "7.1.1",
+                  "bundled": true,
+                  "dependencies": {
+                    "fs.realpath": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "inflight": {
+                      "version": "1.0.6",
+                      "bundled": true,
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true
+                    },
+                    "minimatch": {
+                      "version": "3.0.3",
+                      "bundled": true,
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.6",
+                          "bundled": true,
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.4.2",
+                              "bundled": true
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "semver": {
+              "version": "5.3.0",
+              "bundled": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "dependencies": {
+                "block-stream": {
+                  "version": "0.0.9",
+                  "bundled": true
+                },
+                "fstream": {
+                  "version": "1.0.10",
+                  "bundled": true,
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.9",
+                      "bundled": true
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "bundled": true
+                }
+              }
+            },
+            "tar-pack": {
+              "version": "3.3.0",
+              "bundled": true,
+              "dependencies": {
+                "debug": {
+                  "version": "2.2.0",
+                  "bundled": true,
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "fstream": {
+                  "version": "1.0.10",
+                  "bundled": true,
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.9",
+                      "bundled": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true
+                    }
+                  }
+                },
+                "fstream-ignore": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true
+                    },
+                    "minimatch": {
+                      "version": "3.0.3",
+                      "bundled": true,
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.6",
+                          "bundled": true,
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.4.2",
+                              "bundled": true
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "bundled": true,
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.1.5",
+                  "bundled": true,
+                  "dependencies": {
+                    "buffer-shims": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "bundled": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "bundled": true
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "uid-number": {
+                  "version": "0.0.6",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",

--- a/nuxt-project/package-lock.json
+++ b/nuxt-project/package-lock.json
@@ -1354,6 +1354,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "detect-file": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+      "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM="
+    },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -1914,6 +1919,11 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc="
     },
+    "expand-tilde": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk="
+    },
     "express": {
       "version": "4.15.3",
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
@@ -2013,6 +2023,16 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c="
     },
+    "findup-sync": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+      "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI="
+    },
+    "flagged-respawn": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
+      "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU="
+    },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
@@ -2086,6 +2106,11 @@
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
+    },
+    "fs-exists-sync": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
     },
     "fs-extra": {
       "version": "3.0.1",
@@ -2657,6 +2682,11 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true
     },
+    "generic-pool": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.5.4.tgz",
+      "integrity": "sha1-OMYYhRPhQDCUjsblz2VSPZd5KZs="
+    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -2676,6 +2706,30 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg="
+    },
+    "global-modules": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+      "dependencies": {
+        "is-windows": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+        }
+      }
+    },
+    "global-prefix": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+      "dependencies": {
+        "is-windows": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+        }
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -2775,6 +2829,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg="
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw="
     },
     "hosted-git-info": {
       "version": "2.5.0",
@@ -3241,6 +3300,58 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
     },
+    "knex": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.13.0.tgz",
+      "integrity": "sha1-CN1JT2u2SSiTTuydrDR4ehTKX6Q=",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+        },
+        "interpret": {
+          "version": "0.6.6",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
+          "integrity": "sha1-/s16GOfOXKar+5U+H4YhOknxYls="
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "minimist": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+        }
+      }
+    },
     "latest-version": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
@@ -3262,6 +3373,11 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true
+    },
+    "liftoff": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.5.tgz",
+      "integrity": "sha1-mYwods/0hLED5EI7k9NW2kRzTJE="
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -3918,6 +4034,11 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
     },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+    },
     "parseurl": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
@@ -3976,6 +4097,11 @@
       "version": "3.0.12",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
       "integrity": "sha1-vjZ4XFBn6kjYBv+SMojF91C2uKI="
+    },
+    "pg-connection-string": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
     },
     "pify": {
       "version": "3.0.0",
@@ -5292,8 +5418,7 @@
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q="
     },
     "reduce-css-calc": {
       "version": "1.3.0",
@@ -5429,6 +5554,11 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU="
+    },
+    "resolve-dir": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4="
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -5788,6 +5918,18 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
+    "tildify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.0.0.tgz",
+      "integrity": "sha1-KgIdtej73gqPi03zetqo+x05190=",
+      "dependencies": {
+        "user-home": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+        }
+      }
+    },
     "timed-out": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
@@ -6011,6 +6153,18 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
       "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
       "dev": true
+    },
+    "v8flags": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "dependencies": {
+        "user-home": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+        }
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/nuxt-project/package.json
+++ b/nuxt-project/package.json
@@ -21,6 +21,7 @@
     "lodash": "^4.17.4",
     "nodemailer": "^4.0.1",
     "nuxt": "latest",
+    "sqlite3": "^3.1.8",
     "superagent": "^3.5.2",
     "winston": "^2.3.1"
   },

--- a/nuxt-project/package.json
+++ b/nuxt-project/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "nuxt build && backpack build",
     "dev": "backpack dev",
+    "inspect": "node --inspect build/main.js",
     "start": "cross-env NODE_ENV=production node build/main.js",
     "generate": "nuxt generate",
     "lint": "eslint --ext .js --ignore-path .gitignore .",

--- a/nuxt-project/package.json
+++ b/nuxt-project/package.json
@@ -17,6 +17,7 @@
     "body-parser": "^1.17.1",
     "cross-env": "^5.0.0",
     "express": "^4.15.2",
+    "knex": "^0.13.0",
     "lodash": "^4.17.4",
     "nodemailer": "^4.0.1",
     "nuxt": "latest",


### PR DESCRIPTION

Moved travis.yml to the root folder and now the install process moves into the project folder, this allows the travis file to be found and builds to be made.

Fixed a http status code from 500 to 503 where the email service would be unavailable

Fixed contactEndpoint by correctly contacting requiring the correct parms and removed the param requirements within status.

Introduced the volunteerEndpoint and editorEndpoint, preplanning code for hooking into the volunteer web and updating content with the page editor. 

commented existing code.

adjusted formatting to LF to follow eslint airbnb styling.

A database wrapper has been added to preplan for the implementation of a internal database sqlite3, etc. Still in discussion.

Fixed editorEndpoint for updateById by setting it to post from get.

Database wrapper now supports getContentByid, DoesIdExist, updateContentbyId and getStatus. All doing as name explains.

Email status is defaulted to online unless it fails instead of the otherway around.

Editor middleware now contains, validateDatabaseConnectionStatus, validateContentId, validateAuthenticationToken (template), validateContentBeingUpdated, sendContentByIdForRequestingUser and updateContentByIdForRequestingUser for most requirements with the page editor flow.

Editor now contains routes for gather by id and update by id, routes are now active but not working due to the database status being offline. (users would get a 503)

knex, Sqlite3 is now in the package json for required packages.

Stopped using reserved http names ad component names.